### PR TITLE
restore deleted shop by changing their status

### DIFF
--- a/super_admin_1/__init__.py
+++ b/super_admin_1/__init__.py
@@ -39,14 +39,16 @@ def create_app():
 
     # imports blueprints
     from super_admin_1.shop.del_shop import del_shop
+    from super_admin_1.shop.restore_shop import restore_shop
     from super_admin_1.products.restore_product import restore_product
     from super_admin_1.shop.unban_vendor import shop_blueprint
     from super_admin_1.products.delete_product import product_delete
     from super_admin_1.shop.shop_activity import events
     from super_admin_1.shop.ban_vendor import shop
 
-    # register blueprints
+    # register blueprint
     app.register_blueprint(del_shop)
+    app.register_blueprint(restore_shop)
     app.register_blueprint(restore_product)
     app.register_blueprint(product_delete)
     app.register_blueprint(events)

--- a/super_admin_1/shop/restore_shop.py
+++ b/super_admin_1/shop/restore_shop.py
@@ -3,12 +3,11 @@
 from super_admin_1 import db
 from flask import Blueprint, jsonify, request, abort
 from super_admin_1.models.shop import Shop
-from super_admin_1.models import User
 
-restore_shop = Blueprint("restore_shop", __name__)
+restore_shop = Blueprint("restore_shop", __name__, url_prefix='/api/restore_shop')
 
 
-@restore_shop.route("/shop/<shop_id>", methods=["PATCH"])
+@restore_shop.route("/<shop_id>", methods=["PATCH"])
 def restore_shop(shop_id):
     """restores a deleted shop by setting their "temporary" to "active" fields
     Args:
@@ -18,15 +17,15 @@ def restore_shop(shop_id):
         -success(HTTP 200):shop restored successfully
         -success(HTTP 200): if the shop with provided not marked as deleted
     """
-    data = request.get_json()
-    if not request.is_json:
-        abort(400), "JSON data required"
-    shop = shop.query.filter_by(id=shop_id).first()
+   # data = request.get_json()
+    #if not request.is_json:
+        #abort(400), "JSON data required"
+    shop = Shop.query.filter_by(id=shop_id).first()
     if not shop:
         abort(404), "Invalid shop"
     # change the object attribute from temporary to active
-    if shop.is_deleted == "temporary":
-        shop.is_deleted = "active"
+    if shop.is_deleted == 'temporary':
+        shop.is_deleted = 'active'
         db.session.commit()
         return jsonify({"message": "shop restored sufccessfully"}), 200
     else:

--- a/super_admin_1/shop/restore_shop.py
+++ b/super_admin_1/shop/restore_shop.py
@@ -1,8 +1,8 @@
 """api template for the shop driven operation"""
 
-from super_admin_1 import db
 from flask import Blueprint, jsonify, request, abort
 from super_admin_1.models.shop import Shop
+from super_admin_1.models.alternative import Database as db
 
 restore_shop = Blueprint("restore_shop", __name__, url_prefix='/api/restore_shop')
 
@@ -26,7 +26,11 @@ def restore_shop(shop_id):
     # change the object attribute from temporary to active
     if shop.is_deleted == 'temporary':
         shop.is_deleted = 'active'
-        db.session.commit()
-        return jsonify({"message": "shop restored sufccessfully"}), 200
+        try:
+            db.session.commit()
+            return jsonify({"message": "shop restored sufccessfully"}), 200
+        except Exception as e:
+            db.session.rollback()
+            abort(500, f'Failed to restore shop: {str(e)}')   
     else:
         return jsonify({"message": "shop is not marked as deleted"}), 200


### PR DESCRIPTION
restored deleted shop by changing their status

## Description
This endpoint allows super admin 1 to restore the deleted shop account by changing their status from temporary to active
a shop status can be deleted and this endpoint is to undo that
also fixed some typo and regestered by blue print
#HTTP Method : PATCH
Parameters:
shop_id(string): unique iodentifier of the shop!--- Describe your changes in detail -->

## Related Issue (Link to linear ticket)
https://linear.app/zuri-project-backend/issue/SUP-19/develop-api-endpoints-to-restore-deleted-vendor-accounts
## Motivation and Context
 Why is this change required? What problem does it solve? 
its solves the problem of restoring deleted shops
## How Has This Been Tested?
testing on going with postman

## Types of changes
 What types of changes does your code introduce?

[ x] New feature (non-breaking change which adds functionality)
[x] Fixed some error and registered my blueprint

## Checklist
- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.