### PR TITLE
[Fix]: Add a validation to check if passed vendor_id is in uuid format | and fixed the return jsonified message if SQLAlchemy error occurs to be more descriptive

### DIFF
--- a/super_admin_1/shop/unban_vendor.py
+++ b/super_admin_1/shop/unban_vendor.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 from sqlalchemy.exc import SQLAlchemyError
 from super_admin_1 import db
 from super_admin_1.models.shop import Shop
+import uuid
 
 # Create a Flask Blueprint for shop-related operations
 shop_blueprint = Blueprint("shop_blueprint", __name__, url_prefix="/api/shop")
@@ -29,6 +30,13 @@ def unban_vendor(vendor_id):
     - Proper authentication and authorization checks should be added to secure this endpoint.
     """
     try:
+        try:
+            uuid.UUID(vendor_id, version=4)
+        except ValueError:
+            # If it's a value error, then the string
+            # is not a valid hex code for a UUID.
+            return jsonify({"status": "Error", "message": "Invalid UUID format."}), 400
+
         # Search the database for the vendor with the provided vendor_id
         vendor = Shop.query.filter_by(id=vendor_id).first()
         # If the vendor with the provided ID doesn't exist, return a 404 error
@@ -94,4 +102,4 @@ def unban_vendor(vendor_id):
     except SQLAlchemyError as e:
         # If an error occurs during the database operation, roll back the transaction
         db.session.rollback()
-        return jsonify({"message": "An error occurred.", "error": str(e)}), 500
+        return jsonify({"status": "Error.", "message": str(e)}), 500


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
​
## Description
First, I implemented a UUID format validation check to ensure that the `vendor_id` provided in the URL route adheres to the expected UUID format of 32 hexadecimal characters. If the `vendor_id` doesn't meet this criteria, the code promptly returns a "Invalid UUID format." error with a 400 (Bad Request) status code. Secondly, I improved error handling by catching exceptions like `ValueError` when attempting to create a UUID object, which allows me to return error responses with informative messages and appropriate status codes.
​
## Related Issue (Link to linear ticket)
https://linear.app/zuri-project-backend/issue/SUP-18/develop-api-endpoints-to-unban-vendor-accounts
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​After testing with an int value I was getting an SQLAlchemy error which was not easy to understand, this will solve that issue.
https://spitfire-superadmin-1.onrender.com/api/shop/unban_vendor/12234
```json
{
    "error": "(psycopg2.OperationalError) server closed the connection unexpectedly\n\tThis probably means the server terminated abnormally\n\tbefore or while processing the request.\nserver closed the connection unexpectedly\n\tThis probably means the server terminated abnormally\n\tbefore or while processing the request.\n\n[SQL: SELECT shop.merchant_id AS shop_merchant_id, shop.name AS shop_name, shop.policy_confirmation AS shop_policy_confirmation, shop.restricted AS shop_restricted, shop.admin_status AS shop_admin_status, shop.is_deleted AS shop_is_deleted, shop.reviewed AS shop_reviewed, shop.rating AS shop_rating, shop.id AS shop_id, shop.created_at AS shop_created_at, shop.updated_at AS shop_updated_at \nFROM shop \nWHERE shop.id = %(id_1)s \n LIMIT %(param_1)s]\n[parameters: {'id_1': '12234', 'param_1': 1}]\n(Background on this error at: https://sqlalche.me/e/20/e3q8)",
    "message": "An error occurred."
}
```
## How Has This Been Tested?
```bash
#With integers
kevinkoech357@kevinkoech:~/Personal/HNGx/stage_six_backend/spitfire-super-admin-one$ curl -X PUT http://localhost:5000/api/shop/unban_vendor/1234
{
  "message": "Invalid UUID format.",
  "status": "Error"
}
#With letters
kevinkoech357@kevinkoech:~/Personal/HNGx/stage_six_backend/spitfire-super-admin-one$ curl -X PUT http://localhost:5000/api/shop/unban_vendor/abcd
{
  "message": "Invalid UUID format.",
  "status": "Error"
}
```
​
## Screenshots (if appropriate - Postman, etc):
![9](https://github.com/hngx-org/spitfire-super-admin-one/assets/102515005/75b7572b-cb5c-4d5b-8e6f-7a0ec0b1a7a4)

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.