### PR TITLE
cascade temporary deletion

### DIFF
--- a/super_admin_1/shop/routes.py
+++ b/super_admin_1/shop/routes.py
@@ -515,7 +515,7 @@ def restore_shop(user_id, shop_id):
 @shop.route("delete_shop/<shop_id>", methods=["PATCH"], strict_slashes=False)
 @super_admin_required
 def delete_shop(user_id, shop_id):
-    """Delete a shop"""
+    """Delete a shop and cascade temporary delete action"""
     try:
         shop_id = IdSchema(id=shop_id)
         shop_id = shop_id.id
@@ -548,6 +548,12 @@ def delete_shop(user_id, shop_id):
 
     # delete shop temporarily
     shop.is_deleted = "temporary"
+    # Cascade the temporary delete action to associated products
+    products = Product.query.filter_by(shop_id=shop_id).all()
+    for product in products:
+        product.is_deleted = 'temporary'
+        db.session.add(product)
+
     db.session.commit()
 
     """
@@ -556,7 +562,9 @@ def delete_shop(user_id, shop_id):
     get_user_id = shop.user.id
     action = ShopLogs(shop_id=shop_id, user_id=get_user_id)
     action.log_shop_deleted(delete_type="temporary")
-    return jsonify({"message": "Shop temporarily deleted", "reason": reason}), 204
+
+    return jsonify({'message': "Shop and associated products temporarily deleted" , "reason": reason}), 204
+  
 
 
 # delete shop object permanently out of the DB


### PR DESCRIPTION
## Description
Cacased temporary delete action
​
## Related Issue (Link to linear ticket)
[​my linear ticket](https://linear.app/zuri-project-backend/issue/SUP-34/cascade-temporary-delete-action)
## Motivation and Context
To be able to automatically delete products associated with a shop that has been temporarily deleted 
​
## How Has This Been Tested?
it has been tested on my local and postman. 
​
## Screenshots (if appropriate - Postman, etc):
![zainab](https://github.com/hngx-org/spitfire-super-admin-one/assets/70825458/2a681d40-3b3c-4f51-9587-d636a0a237f7)

​
![image](https://github.com/hngx-org/spitfire-super-admin-one/assets/70825458/3a206eb3-719f-4673-8041-df33fdcdf461)

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply: 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.